### PR TITLE
Fix $RemoteSpec variable in setup.ps1

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -95,7 +95,7 @@ if (Test-Path $RcloneConf) {
 }
 
 # 6  Generate backup.ps1
-$RemoteSpec = "${Remote}:$RemotePath"
+$RemoteSpec = "${RemoteName}:$RemotePath"
 $backup = @"
 # backup.ps1 – incremental SFTP mirror with snapshots & optional Brevo alert
 param(


### PR DESCRIPTION
## Summary
- fix variable name in `setup.ps1` so `$RemoteSpec` uses `$RemoteName`

## Testing
- `pwsh -Command "Write-Host 'pwsh available'"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684375b9088c8332ad9605ab21b4ec43