### PR TITLE
Ensure CRLF in generated backup.ps1

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -152,7 +152,13 @@ if (`$BrevoKey -and `$BrevoSender -and `$BrevoTo) {
 }
 "@
 
-$backup | Set-Content -Encoding UTF8 $BackupPS1
+# Ensure Windows (CRLF) line endings regardless of host OS
+$backupCRLF = $backup -replace "`n", "`r`n"
+[System.IO.File]::WriteAllText(
+    $BackupPS1,
+    $backupCRLF,
+    [System.Text.UTF8Encoding]::new($true)
+)
 Write-Host "backup.ps1 created"
 
 # 7  Task Scheduler job


### PR DESCRIPTION
## Summary
- normalize line endings in `backup.ps1` generation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68437a89981883329e8233e234f5fa5a