### PR TITLE
Add email summary and retention options

### DIFF
--- a/docs/INSTRUCTIONS.txt
+++ b/docs/INSTRUCTIONS.txt
@@ -31,6 +31,8 @@ Step-by-Step Setup
        2 = every N hours
        3 = weekly on specific days
    • **Time/Interval** – depends on option above
+   • **Retention days** – how long to keep snapshots (7–30)
+   • **Brevo sender name** – display name for e-mails [Backup Bot]
 
 6. When the wizard finishes it reports:
    • Settings saved to rclone.conf
@@ -58,9 +60,9 @@ Adjusting Retention
 -------------------
 Open **rclone.conf** and edit the `[backup]` section:
 
-    RetentionDays = 30
+    RetentionDays = 7
 
-Change the value to any integer. Snapshots older than that many days are deleted each run.
+Change the value to any integer up to 30. Snapshots older than that many days are deleted each run.
 
 Changing Schedule Later
 -----------------------

--- a/docs/README.txt
+++ b/docs/README.txt
@@ -11,7 +11,7 @@ Main points
 -----------
 * Mirrors the remote server into current\
 * Creates dated snapshots in archive\YYYY-MM-DD_HHMMSS\
-* Keeps only the last 30 days of snapshots (changeable)
+* Keeps snapshots for 7 days by default (configurable up to 30)
 * Runs on a schedule you choose (daily, every N hours, or weekly)
 * Shows live progress in the console and in backup.log
 * Optional Brevo e-mail when a run finishes
@@ -73,5 +73,7 @@ YOUR_BREVO_KEY
 
 Sender Email:
 your_sender_email@example.com
+Sender Name:
+Backup Bot
 
 send to: <any email>


### PR DESCRIPTION
## Summary
- allow backup retention between 7 and 30 days
- support Brevo sender display name
- record last run time and include summary details in alert email
- document new defaults and options

## Testing
- `pwsh -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684383a2232c8332987dd15fae26290f