### PR TITLE
Include remote details in Brevo email

### DIFF
--- a/backup.ps1
+++ b/backup.ps1
@@ -31,6 +31,14 @@ if (-not $cfg) {
     exit 1
 }
 
+# pull remote connection info
+$RemoteName = ($cfg['Remote'] -split ':')[0]
+$remoteCfg = Get-IniSection $ConfPath $RemoteName
+$remoteType = if ($remoteCfg['type']) { $remoteCfg['type'] } else { '?' }
+$remoteHost = if ($remoteCfg['host']) { $remoteCfg['host'] } else { '?' }
+$remotePort = if ($remoteCfg['port']) { $remoteCfg['port'] } else { '?' }
+$remoteUser = if ($remoteCfg['user']) { $remoteCfg['user'] } else { '?' }
+
 $Remote        = $cfg['Remote']
 $Current       = $cfg['Current']
 $ArchiveRoot   = $cfg['ArchiveRoot']
@@ -105,7 +113,11 @@ if ($BrevoKey -and $BrevoSender -and $BrevoTo) {
         "Backup run: $Status",
         "Start    : $Start",
         "End      : $End",
-        "Duration : $([math]::Round($Duration.TotalMinutes,2)) minutes"
+        "Duration : $([math]::Round($Duration.TotalMinutes,2)) minutes",
+        "Remote type: $remoteType",
+        "Remote host: $remoteHost",
+        "Remote port: $remotePort",
+        "Remote user: $remoteUser"
     )
     if ($LastRun) { $BodyLines += "Previous : $LastRun" }
     $BodyLines += "Current dir : $Current"

--- a/docs/README.txt
+++ b/docs/README.txt
@@ -14,7 +14,7 @@ Main points
 * Keeps snapshots for 7 days by default (configurable up to 30)
 * Runs on a schedule you choose (daily, every N hours, or weekly)
 * Shows live progress in the console and in backup.log
-* Optional Brevo e-mail when a run finishes
+* Optional Brevo e-mail when a run finishes, including remote type, host, port and user
 
 Folder layout
 -------------


### PR DESCRIPTION
## Summary
- parse remote config from `rclone.conf`
- include type, host, port and user details in Brevo email
- mention new email info in docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843860036f88332aed37b40213ce0fe