### PR TITLE
Add required SFTP credential checks

### DIFF
--- a/docs/INSTRUCTIONS.txt
+++ b/docs/INSTRUCTIONS.txt
@@ -33,6 +33,7 @@ If you host on WPX.NET you will need an SFTP login for the backup kit.
    • **Port**        – 22 (default) or 2222 for WPX
    • **Username**    – your SFTP login
    • **Password**    – typed invisibly
+     (the wizard will re-prompt if server, user or password are blank)
    • **Remote source path** – `/` for entire account or `/public_html`
    • **Local destination folder** – e.g. `D:\Backups\MySite`
    • **Schedule**    – choose:

--- a/docs/README.txt
+++ b/docs/README.txt
@@ -43,6 +43,7 @@ Quick start
 3. Run:
        Set-ExecutionPolicy -Scope Process Bypass -Force .\setup.ps1
 4. Answer the prompts
+   (the wizard re-prompts if the server, username or password are blank)
 
 WPX.NET: create an SFTP user
 ----------------------------
@@ -68,6 +69,8 @@ See INSTRUCTIONS.txt for step-by-step details and troubleshooting.
 SFTP CREDENTIALS
 ----------
 FTP Settings
+
+The server, username and password are required; setup re-prompts until all three are provided.
 
 SFTP Server : your_sftp_host or (your_sftp_ip)
 Port : 2222

--- a/setup.ps1
+++ b/setup.ps1
@@ -20,10 +20,21 @@ if (-not (Test-Path $RcloneExe)) {
 }
 
 # 1  SFTP credentials
-$SftpHost = Read-Host 'SFTP server (e.g. s20.wpxhosting.com)'
+$SftpHost = ''
+while (-not $SftpHost) {
+    $SftpHost = Read-Host 'SFTP server (e.g. s20.wpxhosting.com)'
+}
 $SftpPort = Read-Host 'Port [22 or 2222 (required by WPX.NET)]'; if (-not $SftpPort) { $SftpPort = 22 }
-$SftpUser = Read-Host 'SFTP username'
-$SecurePw = Read-Host 'SFTP password' -AsSecureString
+$SftpUser = ''
+while (-not $SftpUser) {
+    $SftpUser = Read-Host 'SFTP username'
+}
+do {
+    $SecurePw = Read-Host 'SFTP password' -AsSecureString
+    $pwLength = [Runtime.InteropServices.Marshal]::PtrToStringAuto(
+        [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecurePw)
+    ).Length
+} while ($pwLength -eq 0)
 
 # 2  Paths
 $RemotePath = Read-Host 'Remote SOURCE path ( / or /subfolder )'


### PR DESCRIPTION
## Summary
- force users to provide SFTP host, user, and password in setup
- describe the new re-prompt behaviour in INSTRUCTIONS.txt and README.txt

## Testing
- `pwsh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684387509ee48332b9312905c77997be