### PR TITLE
Add MIT license and mention in docs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/README.txt
+++ b/docs/README.txt
@@ -91,3 +91,5 @@ Sender Name:
 Backup Bot
 
 send to: <any email>
+
+This toolkit is distributed under the MIT License. See the LICENSE file in the repository root for details.


### PR DESCRIPTION
## Summary
- add MIT `LICENSE`
- note that the toolkit is licensed under MIT in the documentation

## Testing
- `pwsh` not available, so `setup.ps1` and `backup.ps1` not tested


------
https://chatgpt.com/codex/tasks/task_e_68438ee768ac83329b1ed9cfa09305bd