### PR TITLE
Fix SFTP credential test parameter

### DIFF
--- a/docs/README.txt
+++ b/docs/README.txt
@@ -68,6 +68,11 @@ running the script.
 
 See INSTRUCTIONS.txt for step-by-step details and troubleshooting.
 
+Notes
+-----
+* `setup.ps1` now uses the parameter `-SftpHost` instead of the reserved
+  name `-Host`. This avoids a "Variable not writable" error when entering
+  SFTP credentials.
 
 
 SFTP CREDENTIALS

--- a/setup.ps1
+++ b/setup.ps1
@@ -15,10 +15,10 @@ $TaskName    = 'Portable Rclone Incremental Backup'
 # ─────────────────────────────────────────────────────────────────────
 
 # test SFTP credentials via rclone
-function Test-SftpCredential($Host,$Port,$User,$SecurePw) {
+function Test-SftpCredential($SftpHost,$Port,$User,$SecurePw) {
     $plain = [Runtime.InteropServices.Marshal]::PtrToStringAuto(
         [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecurePw))
-    & $RcloneExe lsf ':sftp:/' --sftp-host=$Host --sftp-port=$Port `
+    & $RcloneExe lsf ':sftp:/' --sftp-host=$SftpHost --sftp-port=$Port `
         --sftp-user=$User --sftp-pass=$plain 1>$null 2>$null
     return ($LASTEXITCODE -eq 0)
 }
@@ -48,7 +48,7 @@ while (-not $credOK) {
         ).Length
     } while ($pwLength -eq 0)
     Write-Host 'Testing SFTP credentials...'
-    if (Test-SftpCredential $SftpHost $SftpPort $SftpUser $SecurePw) {
+    if (Test-SftpCredential -SftpHost $SftpHost -Port $SftpPort -User $SftpUser -SecurePw $SecurePw) {
         Write-Host 'SFTP login successful.'
         $credOK = $true
     } else {


### PR DESCRIPTION
## Summary
- rename `Host` parameter to `SftpHost` in `Test-SftpCredential`
- call `Test-SftpCredential` using the new parameter name
- document this change in `docs/README.txt`

## Testing
- `git status --short`
- *Unable to run `setup.ps1` or `backup.ps1` because PowerShell is not available*


------
https://chatgpt.com/codex/tasks/task_e_68438ee8d36083328943c357b557e56e