### PR TITLE
Fix setup abort when rclone prints warnings

### DIFF
--- a/docs/README.txt
+++ b/docs/README.txt
@@ -73,6 +73,8 @@ Notes
 * `setup.ps1` now uses the parameter `-SftpHost` instead of the reserved
   name `-Host`. This avoids a "Variable not writable" error when entering
   SFTP credentials.
+* The credential test no longer aborts the wizard with a `NativeCommandError`
+  when rclone reports missing config or a login failure.
 
 
 SFTP CREDENTIALS

--- a/setup.ps1
+++ b/setup.ps1
@@ -18,9 +18,13 @@ $TaskName    = 'Portable Rclone Incremental Backup'
 function Test-SftpCredential($SftpHost,$Port,$User,$SecurePw) {
     $plain = [Runtime.InteropServices.Marshal]::PtrToStringAuto(
         [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecurePw))
-    & $RcloneExe lsf ':sftp:/' --sftp-host=$SftpHost --sftp-port=$Port `
-        --sftp-user=$User --sftp-pass=$plain 1>$null 2>$null
-    return ($LASTEXITCODE -eq 0)
+    try {
+        & $RcloneExe lsf ':sftp:/' --sftp-host=$SftpHost --sftp-port=$Port `
+            --sftp-user=$User --sftp-pass=$plain 1>$null 2>$null
+        return ($LASTEXITCODE -eq 0)
+    } catch {
+        return $false
+    }
 }
 
 Write-Host "`n=== Portable rclone backup setup ===`n"


### PR DESCRIPTION
## Summary
- prevent `NativeCommandError` from stopping `setup.ps1`
- note the credential check behaviour in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68439175e0748332b56ff6ba8b01fe1f