### PR TITLE
Fix SFTP credential quoting

### DIFF
--- a/docs/INSTRUCTIONS.txt
+++ b/docs/INSTRUCTIONS.txt
@@ -35,6 +35,7 @@ If you host on WPX.NET you will need an SFTP login for the backup kit.
    • **Password**    – typed invisibly
      (the wizard re-prompts if server, user or password are blank)
      *Credentials are tested before continuing*
+     (spaces and special characters are supported)
    • **Remote source path** – `/` for entire account or `/public_html`\
      *(press Enter for `/`)*
    • **Local destination folder** – e.g. `D:\Backups\MySite`\

--- a/docs/README.txt
+++ b/docs/README.txt
@@ -75,6 +75,7 @@ Notes
   SFTP credentials.
 * The credential test no longer aborts the wizard with a `NativeCommandError`
   when rclone reports missing config or a login failure.
+* Quoted SFTP parameters so passwords with spaces or special characters work.
 
 
 SFTP CREDENTIALS

--- a/restore.ps1
+++ b/restore.ps1
@@ -26,8 +26,8 @@ function Prompt-SftpCredential {
         Write-Host 'Testing credentials...'
         $plain = [Runtime.InteropServices.Marshal]::PtrToStringAuto([
             Runtime.InteropServices.Marshal]::SecureStringToBSTR($securePw))
-        & $RcloneExe lsf ':sftp:/' --sftp-host=$host --sftp-port=$port \
-            --sftp-user=$user --sftp-pass=$plain 1>$null 2>$null
+        & $RcloneExe lsf ':sftp:/' --sftp-host="$host" --sftp-port="$port" \
+            --sftp-user="$user" --sftp-pass="$plain" 1>$null 2>$null
         if ($LASTEXITCODE -eq 0) { Write-Host 'SFTP login OK.'; $credOK=$true }
         else { Write-Warning 'Login failed. Please re-enter.' }
     }
@@ -76,8 +76,8 @@ $obscured = & $RcloneExe obscure $plainPw
 $remoteSpec = ":sftp:$RemotePath"
 
 Write-Host "\nRestoring snapshot '$($snaps[$choice-1].Name)' to $creds.host ..."
-& $RcloneExe sync $SnapPath $remoteSpec --sftp-host=$creds.host --sftp-port=$creds.port \
-    --sftp-user=$creds.user --sftp-pass=$obscured --progress --stats=10s
+& $RcloneExe sync $SnapPath $remoteSpec --sftp-host="$creds.host" --sftp-port="$creds.port" \
+    --sftp-user="$creds.user" --sftp-pass="$obscured" --progress --stats=10s
 
 if ($LASTEXITCODE -eq 0) {
     Write-Host 'Restore completed successfully.'

--- a/setup.ps1
+++ b/setup.ps1
@@ -19,8 +19,8 @@ function Test-SftpCredential($SftpHost,$Port,$User,$SecurePw) {
     $plain = [Runtime.InteropServices.Marshal]::PtrToStringAuto(
         [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecurePw))
     try {
-        & $RcloneExe lsf ':sftp:/' --sftp-host=$SftpHost --sftp-port=$Port `
-            --sftp-user=$User --sftp-pass=$plain 1>$null 2>$null
+        & $RcloneExe lsf ':sftp:/' --sftp-host="$SftpHost" --sftp-port="$Port" `
+            --sftp-user="$User" --sftp-pass="$plain" 1>$null 2>$null
         return ($LASTEXITCODE -eq 0)
     } catch {
         return $false
@@ -142,9 +142,9 @@ $Obscured = & $RcloneExe obscure $PlainPw
 $RemoteName = 'remote'
 $env:RCLONE_CONFIG = $RcloneConf
 if (Test-Path $RcloneConf) {
-    & $RcloneExe config update $RemoteName host=$SftpHost port=$SftpPort user=$SftpUser pass=$Obscured
+    & $RcloneExe config update $RemoteName host="$SftpHost" port="$SftpPort" user="$SftpUser" pass="$Obscured"
 } else {
-    & $RcloneExe config create $RemoteName sftp host=$SftpHost port=$SftpPort user=$SftpUser pass=$Obscured
+    & $RcloneExe config create $RemoteName sftp host="$SftpHost" port="$SftpPort" user="$SftpUser" pass="$Obscured"
 }
 
 # 7  Store settings in rclone.conf


### PR DESCRIPTION
## Summary
- quote SFTP credentials when calling rclone
- document that spaces/special chars in passwords work

## Testing
- `powershell -Command "echo hi"` *(fails: command not found)*
- `pwsh setup.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684394ff5e24833285951298498d66b0