### PR TITLE
Fix SFTP credential checks

### DIFF
--- a/docs/INSTRUCTIONS.txt
+++ b/docs/INSTRUCTIONS.txt
@@ -85,9 +85,11 @@ updates rclone.conf but keeps existing credentials.
 
 Troubleshooting
 ---------------
-• Log file lives next to *archive\…* as `backup.log`.  
+• Log file lives next to *archive\…* as `backup.log`.
 • Task Scheduler → “Task Scheduler Library” → find the job → *History* tab
-  shows last run/next run and exit codes.  
+  shows last run/next run and exit codes.
+• If valid credentials are repeatedly rejected, update the scripts and retry –
+  the login check now uses an obscured password.
 • If storage fills, prune archive or move the destination folder.
 
 Need a full restore?

--- a/docs/README.txt
+++ b/docs/README.txt
@@ -75,6 +75,7 @@ Notes
   SFTP credentials.
 * The credential test no longer aborts the wizard with a `NativeCommandError`
   when rclone reports missing config or a login failure.
+* Credential checks now use an obscured password so valid logins no longer fail.
 * Quoted SFTP parameters so passwords with spaces or special characters work.
 
 

--- a/restore.ps1
+++ b/restore.ps1
@@ -24,10 +24,11 @@ function Prompt-SftpCredential {
             ).Length
         } while ($len -eq 0)
         Write-Host 'Testing credentials...'
-        $plain = [Runtime.InteropServices.Marshal]::PtrToStringAuto([
-            Runtime.InteropServices.Marshal]::SecureStringToBSTR($securePw))
+        $plain    = [Runtime.InteropServices.Marshal]::PtrToStringAuto([
+                        Runtime.InteropServices.Marshal]::SecureStringToBSTR($securePw))
+        $obscured = & $RcloneExe obscure $plain
         & $RcloneExe lsf ':sftp:/' --sftp-host="$host" --sftp-port="$port" \
-            --sftp-user="$user" --sftp-pass="$plain" 1>$null 2>$null
+            --sftp-user="$user" --sftp-pass="$obscured" 1>$null 2>$null
         if ($LASTEXITCODE -eq 0) { Write-Host 'SFTP login OK.'; $credOK=$true }
         else { Write-Warning 'Login failed. Please re-enter.' }
     }

--- a/setup.ps1
+++ b/setup.ps1
@@ -16,11 +16,12 @@ $TaskName    = 'Portable Rclone Incremental Backup'
 
 # test SFTP credentials via rclone
 function Test-SftpCredential($SftpHost,$Port,$User,$SecurePw) {
-    $plain = [Runtime.InteropServices.Marshal]::PtrToStringAuto(
-        [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecurePw))
+    $plain    = [Runtime.InteropServices.Marshal]::PtrToStringAuto(
+                   [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecurePw))
+    $obscured = & $RcloneExe obscure $plain
     try {
         & $RcloneExe lsf ':sftp:/' --sftp-host="$SftpHost" --sftp-port="$Port" `
-            --sftp-user="$User" --sftp-pass="$plain" 1>$null 2>$null
+            --sftp-user="$User" --sftp-pass="$obscured" 1>$null 2>$null
         return ($LASTEXITCODE -eq 0)
     } catch {
         return $false


### PR DESCRIPTION
## Summary
- use an obscured password when testing credentials
- document credential check fix
- mention the fix in troubleshooting tips

## Testing
- `pwsh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843963c3d3083328a641da418b5e93f