### PR TITLE
Remove credential validation loops

### DIFF
--- a/docs/INSTRUCTIONS.txt
+++ b/docs/INSTRUCTIONS.txt
@@ -33,13 +33,12 @@ If you host on WPX.NET you will need an SFTP login for the backup kit.
    • **Port**        – 22 (default) or 2222 for WPX
    • **Username**    – your SFTP login
    • **Password**    – typed invisibly
-     (the wizard re-prompts if server, user or password are blank)
-     *Credentials are tested before continuing*
-     (spaces and special characters are supported)
-   • **Remote source path** – `/` for entire account or `/public_html`\
-     *(press Enter for `/`)*
-   • **Local destination folder** – e.g. `D:\Backups\MySite`\
-     *(must be a valid local path and cannot be blank; the wizard re-prompts until valid)*
+    (the wizard re-prompts if server, user or password are blank)
+    (spaces and special characters are supported)
+    • **Remote source path** – `/` for entire account or `/public_html`\
+      *(press Enter for `/`)*
+    • **Local destination folder** – e.g. `D:\Backups\MySite`\
+      *(must be a valid local path and cannot be blank; the wizard re-prompts until valid)*
    • **Schedule**    – choose:
        1 = daily at HH:MM
        2 = every N hours
@@ -88,13 +87,12 @@ Troubleshooting
 • Log file lives next to *archive\…* as `backup.log`.
 • Task Scheduler → “Task Scheduler Library” → find the job → *History* tab
   shows last run/next run and exit codes.
-• If valid credentials are repeatedly rejected, update the scripts and retry –
-  the login check now uses an obscured password.
+• If valid credentials are repeatedly rejected, update the scripts and retry.
 • If storage fills, prune archive or move the destination folder.
 
 Need a full restore?
 --------------------
-1. Copy the desired snapshot folder over *current* (or pull single files).  
+1. Copy the desired snapshot folder over *current* (or pull single files).
 2. Run `backup.ps1` to re-sync the restored content to the SFTP server.
 
 Enjoy safe, incremental backups!  🙂

--- a/docs/README.txt
+++ b/docs/README.txt
@@ -44,7 +44,7 @@ Quick start
        Set-ExecutionPolicy -Scope Process Bypass -Force .\setup.ps1
 4. Answer the prompts
    (the wizard re-prompts if the server, username or password are blank.
-    Credentials are tested before continuing. Press **Enter** for the remote path to use `/`. **You must type a destination folder; the wizard re-prompts until it is valid.**
+    Press **Enter** for the remote path to use `/`. A destination folder is required and re-prompts until valid.
 
 WPX.NET: create an SFTP user
 ----------------------------
@@ -73,9 +73,6 @@ Notes
 * `setup.ps1` now uses the parameter `-SftpHost` instead of the reserved
   name `-Host`. This avoids a "Variable not writable" error when entering
   SFTP credentials.
-* The credential test no longer aborts the wizard with a `NativeCommandError`
-  when rclone reports missing config or a login failure.
-* Credential checks now use an obscured password so valid logins no longer fail.
 * Quoted SFTP parameters so passwords with spaces or special characters work.
 
 

--- a/restore.ps1
+++ b/restore.ps1
@@ -10,28 +10,17 @@ if (-not (Test-Path $RcloneExe)) {
 }
 
 function Prompt-SftpCredential {
-    $credOK = $false
-    while (-not $credOK) {
-        $host = ''
-        while (-not $host) { $host = Read-Host 'SFTP server' }
-        $port = Read-Host 'Port [22]'; if (-not $port) { $port = 22 }
-        $user = ''
-        while (-not $user) { $user = Read-Host 'SFTP username' }
-        do {
-            $securePw = Read-Host 'SFTP password' -AsSecureString
-            $len = [Runtime.InteropServices.Marshal]::PtrToStringAuto([
-                Runtime.InteropServices.Marshal]::SecureStringToBSTR($securePw)
-            ).Length
-        } while ($len -eq 0)
-        Write-Host 'Testing credentials...'
-        $plain    = [Runtime.InteropServices.Marshal]::PtrToStringAuto([
-                        Runtime.InteropServices.Marshal]::SecureStringToBSTR($securePw))
-        $obscured = & $RcloneExe obscure $plain
-        & $RcloneExe lsf ':sftp:/' --sftp-host="$host" --sftp-port="$port" \
-            --sftp-user="$user" --sftp-pass="$obscured" 1>$null 2>$null
-        if ($LASTEXITCODE -eq 0) { Write-Host 'SFTP login OK.'; $credOK=$true }
-        else { Write-Warning 'Login failed. Please re-enter.' }
-    }
+    $host = ''
+    while (-not $host) { $host = Read-Host 'SFTP server' }
+    $port = Read-Host 'Port [22]'; if (-not $port) { $port = 22 }
+    $user = ''
+    while (-not $user) { $user = Read-Host 'SFTP username' }
+    do {
+        $securePw = Read-Host 'SFTP password' -AsSecureString
+        $len = [Runtime.InteropServices.Marshal]::PtrToStringAuto(
+            [Runtime.InteropServices.Marshal]::SecureStringToBSTR($securePw)
+        ).Length
+    } while ($len -eq 0)
     return @{ host=$host; port=$port; user=$user; securePw=$securePw }
 }
 


### PR DESCRIPTION
## Summary
- drop `Test-SftpCredential` from `setup.ps1`
- simplify SFTP prompts in `setup.ps1`
- simplify credential prompts in `restore.ps1`
- update docs to match the simpler setup flow

## Testing
- `pwsh -NoLogo -NonInteractive -File setup.ps1` *(fails: command not found)*
- `powershell -NoLogo -NonInteractive -File setup.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a379c6cc8332bd8dee72e26a6c54