### PR TITLE
Document rclone retry message

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,13 @@ No installation is required; simply unzip the folder and run the setup wizard.
 4. Answer the prompts. The first backup will run according to the schedule you choose.
 
 See [docs/README.txt](docs/README.txt) and [docs/INSTRUCTIONS.txt](docs/INSTRUCTIONS.txt) for full instructions and troubleshooting tips.
+
+## Log messages
+
+Rclone may retry a failed operation automatically. When that happens you might see a line like:
+
+```text
+ERROR : Attempt 2/3 succeeded
+```
+
+Even though rclone labels it as an error, this simply means the retry worked and the run continues normally.

--- a/docs/README.txt
+++ b/docs/README.txt
@@ -74,6 +74,8 @@ Notes
   name `-Host`. This avoids a "Variable not writable" error when entering
   SFTP credentials.
 * Quoted SFTP parameters so passwords with spaces or special characters work.
+* `ERROR : Attempt 2/3 succeeded` in `backup.log` means the first try failed but
+  a retry was successful.
 
 
 SFTP CREDENTIALS


### PR DESCRIPTION
## Summary
- note what `Attempt 2/3 succeeded` means in backup logs
- add same explanation to docs

## Testing
- `grep -n " \+$" -n README.md`
- `grep -n " \+$" -n docs/README.txt`
- `awk 'length($0)>120{print NR, length($0)}' README.md`
- `awk 'length($0)>120{print NR, length($0)}' docs/README.txt`


------
https://chatgpt.com/codex/tasks/task_e_6843aa2ddda08332a46dabbdd49a76c2