### PR TITLE
Fix uninstall script not removing scheduled task

### DIFF
--- a/docs/README.txt
+++ b/docs/README.txt
@@ -78,6 +78,7 @@ Notes
 * Quoted SFTP parameters so passwords with spaces or special characters work.
 * `ERROR : Attempt 2/3 succeeded` in `backup.log` means the first try failed but
   a retry was successful.
+* Fixed `uninstall.ps1` so the scheduled task is removed correctly.
 
 
 SFTP CREDENTIALS

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -13,7 +13,7 @@ Write-Host "`n=== PortableBackupKit Uninstall ===`n"
 try {
     $task = Get-ScheduledTask -TaskName $TaskName -ErrorAction Stop  # works even if job is in a sub-folder
     Disable-ScheduledTask  $task | Out-Null
-    Unregister-ScheduledTask $task -Confirm:$false
+    Unregister-ScheduledTask -InputObject $task -Confirm:$false
     Write-Host "OK  Task '$TaskName' removed."
 } catch {
     Write-Host "INFO Task '$TaskName' not found (already removed)."


### PR DESCRIPTION
## Summary
- fix parameter in `uninstall.ps1` so `Unregister-ScheduledTask` works
- document the fix in `docs/README.txt`

## Testing
- `pwsh ./setup.ps1` *(fails: command not found)*
- `pwsh ./backup.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843b6ff4d9c8332a5429c4a9cb2371e