### PR TITLE
Update setup command instructions

### DIFF
--- a/docs/README.txt
+++ b/docs/README.txt
@@ -41,7 +41,7 @@ Quick start
 1. Extract this folder, for example to C:\Tools\PortableBackupKit
 2. Open an *elevated* PowerShell window in that folder
 3. Run:
-       Set-ExecutionPolicy -Scope Process Bypass -Force .\setup.ps1
+       Set-ExecutionPolicy -Scope Process Bypass -Force; .\setup.ps1
 4. Answer the prompts
    (the wizard re-prompts if the server, username or password are blank.
     Press **Enter** for the remote path to use `/`. A destination folder is required and re-prompts until valid.
@@ -78,6 +78,7 @@ Notes
 * Quoted SFTP parameters so passwords with spaces or special characters work.
 * `ERROR : Attempt 2/3 succeeded` in `backup.log` means the first try failed but
   a retry was successful.
+* Run `Set-ExecutionPolicy` and `./setup.ps1` as two commands or join them with a semicolon.
 
 
 SFTP CREDENTIALS

--- a/quick-start.txt
+++ b/quick-start.txt
@@ -4,7 +4,7 @@ PortableBackupKit Quick Start
 1. Extract the folder to any location, for example `C:\Tools\PortableBackupKit`.
 2. Open an **elevated** PowerShell window in that folder.
 3. Run:
-       Set-ExecutionPolicy -Scope Process Bypass -Force .\setup.ps1
+       Set-ExecutionPolicy -Scope Process Bypass -Force; .\setup.ps1
 4. Answer the prompts to configure your SFTP backup.
 5. The scheduled task runs automatically on the schedule you choose.
 


### PR DESCRIPTION
## Summary
- clarify the setup instructions in README and quick-start guide
- mention that `Set-ExecutionPolicy` should run separately or via semicolon

## Testing
- `powershell -Command "Write-Output test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843badad69c83329b549edcafaa660c