### PR TITLE
setup: handle missing remote entry

### DIFF
--- a/docs/README.txt
+++ b/docs/README.txt
@@ -83,6 +83,8 @@ Notes
 * `ERROR : Attempt 2/3 succeeded` in `backup.log` means the first try failed but
   a retry was successful.
 * Run `Set-ExecutionPolicy` and `./setup.ps1` as two commands or join them with a semicolon.
+* `setup.ps1` now checks if the remote entry exists in `rclone.conf` before updating.
+  When missing, it runs `config create` instead of `config update`.
 
 
 SFTP CREDENTIALS

--- a/setup.ps1
+++ b/setup.ps1
@@ -119,7 +119,12 @@ $PlainPw  = [Runtime.InteropServices.Marshal]::PtrToStringAuto(
 $Obscured = & $RcloneExe obscure $PlainPw
 $RemoteName = 'remote'
 $env:RCLONE_CONFIG = $RcloneConf
+$remoteExists = $false
 if (Test-Path $RcloneConf) {
+    $dump = & $RcloneExe config dump
+    $remoteExists = $dump -match "\[$RemoteName\]"
+}
+if ($remoteExists) {
     & $RcloneExe config update $RemoteName host="$SftpHost" port="$SftpPort" user="$SftpUser" pass="$Obscured"
 } else {
     & $RcloneExe config create $RemoteName sftp host="$SftpHost" port="$SftpPort" user="$SftpUser" pass="$Obscured"


### PR DESCRIPTION
## Summary
- check for the remote before updating and create it if absent
- mention new setup behavior in README

## Testing
- `pwsh` *(fails: command not found)*
- `powershell` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843bd3ff0b48332821328443eaf6558