### PR TITLE
Remove obsolete SftpHost note

### DIFF
--- a/docs/README.txt
+++ b/docs/README.txt
@@ -76,9 +76,6 @@ See INSTRUCTIONS.txt for step-by-step details and troubleshooting.
 
 Notes
 -----
-* `setup.ps1` now uses the parameter `-SftpHost` instead of the reserved
-  name `-Host`. This avoids a "Variable not writable" error when entering
-  SFTP credentials.
 * Quoted SFTP parameters so passwords with spaces or special characters work.
 * `ERROR : Attempt 2/3 succeeded` in `backup.log` means the first try failed but
   a retry was successful.


### PR DESCRIPTION
## Summary
- delete outdated bullet about the `-SftpHost` parameter in `docs/README.txt`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6843bd45f97c8332ae99436a7ad2f664