### PR TITLE
Enhance rclone reliability prompts

### DIFF
--- a/backup.ps1
+++ b/backup.ps1
@@ -49,6 +49,11 @@ $BrevoKey      = $cfg['BrevoKey']
 $BrevoSender   = $cfg['BrevoSender']
 $BrevoTo       = $cfg['BrevoTo']
 $SubjectBase   = $cfg['SubjectBase']
+$Retries         = if ($cfg['Retries']) { [int]$cfg['Retries'] } else { 3 }
+$RetrySleep      = if ($cfg['RetrySleep']) { [int]$cfg['RetrySleep'] } else { 30 }
+$LowLevelRetries = if ($cfg['LowLevelRetries']) { [int]$cfg['LowLevelRetries'] } else { 10 }
+$TimeoutSec      = if ($cfg['TimeoutSec']) { [int]$cfg['TimeoutSec'] } else { 300 }
+$ConnectTimeout  = if ($cfg['ConnectTimeout']) { [int]$cfg['ConnectTimeout'] } else { 30 }
 
 $env:RCLONE_CONFIG = $ConfPath
 $Rclone = Join-Path $PSScriptRoot 'rclone.exe'
@@ -70,7 +75,10 @@ $LogFile = Join-Path (Split-Path $ArchiveRoot) 'backup.log'
     --backup-dir="$Archive" `
     --progress --stats=10s --stats-one-line `
     --log-file="$LogFile" --log-level INFO `
-    --stats-log-level NOTICE
+    --stats-log-level NOTICE `
+    --retries $Retries --retries-sleep ${RetrySleep}s `
+    --low-level-retries $LowLevelRetries `
+    --timeout ${TimeoutSec}s --contimeout ${ConnectTimeout}s
 
 Get-ChildItem $ArchiveRoot -Directory |
     Where-Object { $_.LastWriteTime -lt (Get-Date).AddDays(-$RetentionDays) } |

--- a/docs/INSTRUCTIONS.txt
+++ b/docs/INSTRUCTIONS.txt
@@ -45,6 +45,11 @@ If you host on WPX.NET you will need an SFTP login for the backup kit.
        3 = weekly on specific days
    • **Time/Interval** – depends on option above
    • **Retention days** – how long to keep snapshots (7–30)
+   • **Retries** – times to retry a failed transfer [3]
+   • **Retry wait** – seconds to pause between retries [30]
+   • **Low-level retries** – network retry count [10]
+   • **I/O timeout** – seconds before a stalled transfer fails [300]
+   • **Connect timeout** – seconds to wait for a connection [30]
    • **Brevo sender name** – display name for e-mails [Backup Bot]
    • E-mail summary shows only total files and data transferred
    • backup.ps1 runs rclone with `--stats-log-level NOTICE` so those totals are logged

--- a/docs/README.txt
+++ b/docs/README.txt
@@ -17,6 +17,7 @@ Main points
 * Optional Brevo e-mail when a run finishes, summarizing remote info, files transferred and data volume
 * `update.ps1` pulls new versions of these scripts via git
 * Uses `--stats-log-level NOTICE` so totals appear in the log and e-mail
+* Setup lets you set timeouts and retry counts to avoid stalled transfers
 
 
 Folder layout
@@ -82,6 +83,7 @@ Notes
 * Run `Set-ExecutionPolicy` and `./setup.ps1` as two commands or join them with a semicolon.
 * `setup.ps1` now checks if the remote entry exists in `rclone.conf` before updating.
   When missing, it runs `config create` instead of `config update`.
+* Reliability options (timeouts and retries) are stored in `rclone.conf`
 
 
 SFTP CREDENTIALS

--- a/setup.ps1
+++ b/setup.ps1
@@ -95,10 +95,23 @@ switch ($Choice) {
     }
 }
 
+
 $RetentionDays = Read-Host 'Days to keep snapshots [3, max 30]'
 if (-not $RetentionDays) { $RetentionDays = 3 }
 $RetentionDays = [int]$RetentionDays
 if ($RetentionDays -gt 30) { $RetentionDays = 30 }
+
+# 4  Reliability settings
+$Retries = Read-Host 'Retry attempts [3]'
+if (-not $Retries) { $Retries = 3 }
+$RetrySleep = Read-Host 'Seconds to wait between retries [30]'
+if (-not $RetrySleep) { $RetrySleep = 30 }
+$LowLevelRetries = Read-Host 'Low-level retries [10]'
+if (-not $LowLevelRetries) { $LowLevelRetries = 10 }
+$TimeoutSec = Read-Host 'I/O timeout in seconds [300]'
+if (-not $TimeoutSec) { $TimeoutSec = 300 }
+$ConnectTimeout = Read-Host 'Connect timeout in seconds [30]'
+if (-not $ConnectTimeout) { $ConnectTimeout = 30 }
 
 # 5  OPTIONAL Brevo e-mail
 $BrevoKey = Read-Host 'Brevo API key (Enter = skip e-mail)'
@@ -138,6 +151,11 @@ Remote        = $RemoteSpec
 Current       = $LocalRoot\current
 ArchiveRoot   = $LocalRoot\archive
 RetentionDays = $RetentionDays
+Retries       = $Retries
+RetrySleep    = $RetrySleep
+LowLevelRetries = $LowLevelRetries
+TimeoutSec    = $TimeoutSec
+ConnectTimeout = $ConnectTimeout
 BrevoKey      = $BrevoKey
 BrevoSender   = $BrevoSender
 BrevoName     = $BrevoName


### PR DESCRIPTION
## Summary
- ask for retry and timeout parameters during setup
- store new reliability settings in rclone.conf
- apply those options when running rclone
- document the new prompts in README and INSTRUCTIONS

## Testing
- `git status --short`
- *Manual testing not run: PowerShell unavailable*


------
https://chatgpt.com/codex/tasks/task_e_68443e0395588332b4a9b2a1ea0af3f3