### PR TITLE
Add retry defaults from config

### DIFF
--- a/docs/INSTRUCTIONS.txt
+++ b/docs/INSTRUCTIONS.txt
@@ -86,8 +86,8 @@ Change the value to any integer up to 30. Snapshots older than that many days ar
 
 Changing Schedule Later
 -----------------------
-Run **setup.ps1** again; it overwrites the Task Scheduler trigger and
-updates rclone.conf but keeps existing credentials.
+Run **setup.ps1** again; it overwrites the Task Scheduler trigger and updates rclone.conf
+but keeps existing credentials. Saved retry and timeout settings appear as the defaults.
 
 Updating
 --------

--- a/docs/README.txt
+++ b/docs/README.txt
@@ -83,7 +83,7 @@ Notes
 * Run `Set-ExecutionPolicy` and `./setup.ps1` as two commands or join them with a semicolon.
 * `setup.ps1` now checks if the remote entry exists in `rclone.conf` before updating.
   When missing, it runs `config create` instead of `config update`.
-* Reliability options (timeouts and retries) are stored in `rclone.conf`
+* Reliability options (timeouts and retries) are stored in `rclone.conf`; rerunning the wizard shows them as defaults.
 
 
 SFTP CREDENTIALS

--- a/setup.ps1
+++ b/setup.ps1
@@ -14,11 +14,33 @@ $BackupPS1   = Join-Path $KitDir 'backup.ps1'
 $TaskName    = 'Portable Rclone Incremental Backup'
 # ─────────────────────────────────────────────────────────────────────
 
+function Get-IniSection($Path, $Section) {
+    $lines = Get-Content $Path
+    $inside = $false
+    $result = @{}
+    foreach ($line in $lines) {
+        if ($line -match '^\s*\[(.+)\]\s*$') {
+            $inside = ($matches[1] -eq $Section)
+            continue
+        }
+        if ($inside -and $line -match '^\s*([^=]+?)\s*=\s*(.*)$') {
+            $key = $matches[1].Trim()
+            $val = $matches[2].Trim()
+            $result[$key] = $val
+        }
+    }
+    return $result
+}
 
 Write-Host "`n=== Portable rclone backup setup ===`n"
 if (-not (Test-Path $RcloneExe)) {
     Write-Error "rclone.exe not found in $KitDir."
     exit 1
+}
+
+$BackupDefaults = @{}
+if (Test-Path $RcloneConf) {
+    $BackupDefaults = Get-IniSection $RcloneConf 'backup'
 }
 
 # 1  SFTP credentials
@@ -102,16 +124,22 @@ $RetentionDays = [int]$RetentionDays
 if ($RetentionDays -gt 30) { $RetentionDays = 30 }
 
 # 4  Reliability settings
-$Retries = Read-Host 'Retry attempts [3]'
-if (-not $Retries) { $Retries = 3 }
-$RetrySleep = Read-Host 'Seconds to wait between retries [30]'
-if (-not $RetrySleep) { $RetrySleep = 30 }
-$LowLevelRetries = Read-Host 'Low-level retries [10]'
-if (-not $LowLevelRetries) { $LowLevelRetries = 10 }
-$TimeoutSec = Read-Host 'I/O timeout in seconds [300]'
-if (-not $TimeoutSec) { $TimeoutSec = 300 }
-$ConnectTimeout = Read-Host 'Connect timeout in seconds [30]'
-if (-not $ConnectTimeout) { $ConnectTimeout = 30 }
+$defRetries        = if ($BackupDefaults['Retries']) { [int]$BackupDefaults['Retries'] } else { 3 }
+$defRetrySleep     = if ($BackupDefaults['RetrySleep']) { [int]$BackupDefaults['RetrySleep'] } else { 30 }
+$defLowLevel       = if ($BackupDefaults['LowLevelRetries']) { [int]$BackupDefaults['LowLevelRetries'] } else { 10 }
+$defTimeout        = if ($BackupDefaults['TimeoutSec']) { [int]$BackupDefaults['TimeoutSec'] } else { 300 }
+$defConnectTimeout = if ($BackupDefaults['ConnectTimeout']) { [int]$BackupDefaults['ConnectTimeout'] } else { 30 }
+
+$Retries = Read-Host "Retry attempts [$defRetries]"
+if (-not $Retries) { $Retries = $defRetries }
+$RetrySleep = Read-Host "Seconds to wait between retries [$defRetrySleep]"
+if (-not $RetrySleep) { $RetrySleep = $defRetrySleep }
+$LowLevelRetries = Read-Host "Low-level retries [$defLowLevel]"
+if (-not $LowLevelRetries) { $LowLevelRetries = $defLowLevel }
+$TimeoutSec = Read-Host "I/O timeout in seconds [$defTimeout]"
+if (-not $TimeoutSec) { $TimeoutSec = $defTimeout }
+$ConnectTimeout = Read-Host "Connect timeout in seconds [$defConnectTimeout]"
+if (-not $ConnectTimeout) { $ConnectTimeout = $defConnectTimeout }
 
 # 5  OPTIONAL Brevo e-mail
 $BrevoKey = Read-Host 'Brevo API key (Enter = skip e-mail)'


### PR DESCRIPTION
## Summary
- parse INI sections in `setup.ps1`
- reuse stored retry/timeouts when rerunning setup
- document default reuse in README and INSTRUCTIONS

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68444514a35c83328cb6b37ad6032380