### PR TITLE
Add Git install hint

### DIFF
--- a/docs/README.txt
+++ b/docs/README.txt
@@ -15,7 +15,7 @@ Main points
 * Runs on a schedule you choose (daily, every N hours, or weekly)
 * Shows live progress in the console and in backup.log
 * Optional Brevo e-mail when a run finishes, summarizing remote info, files transferred and data volume
-* `update.ps1` pulls new versions of these scripts via git
+* `update.ps1` pulls new versions of these scripts via git and hints if git is missing
 * Uses `--stats-log-level NOTICE` so totals appear in the log and e-mail
 * Setup lets you set timeouts and retry counts to avoid stalled transfers
 

--- a/update.ps1
+++ b/update.ps1
@@ -3,7 +3,7 @@
 $KitDir = $PSScriptRoot
 
 if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
-    Write-Error 'git executable not found.'
+    Write-Error "git executable not found. Install Git for Windows and ensure 'git' is in your PATH."
     exit 1
 }
 


### PR DESCRIPTION
## Summary
- show a helpful message in `update.ps1` when Git is missing
- note this behaviour in the README

## Testing
- `pwsh -NoLogo -Command ./setup.ps1` *(fails: `pwsh` not found)*
- `pwsh -NoLogo -Command ./backup.ps1` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b066bf8388332b7c8b41cc2125ff5