### PR TITLE
Improve README clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ No installation is required; simply unzip the folder and run the setup wizard.
 
 ## Key scripts
 
-- `setup.ps1` – interactive wizard that collects SFTP credentials, sets the backup schedule and creates `rclone.conf` and a scheduled task.
-- `backup.ps1` – job script run by Task Scheduler. Mirrors the remote into `current`, stores dated snapshots under `archive/` and optionally sends a Brevo email report.
+- `setup.ps1` – interactive wizard that collects SFTP credentials and sets the backup schedule.
+  It creates `rclone.conf` and a scheduled task.
+- `backup.ps1` – job script run by Task Scheduler. Mirrors the remote into `current` and stores
+  dated snapshots under `archive/`. It can optionally send a Brevo email report.
 - `restore.ps1` – restore wizard that uploads a selected snapshot back to the SFTP server.
 - `uninstall.ps1` – removes the scheduled task and can delete configuration files and local backups.
 - `update.ps1` – pulls the latest version of the toolkit from this repository.
@@ -23,7 +25,8 @@ No installation is required; simply unzip the folder and run the setup wizard.
     ```
 4. Answer the prompts. The first backup will run according to the schedule you choose.
 
-See [docs/README.txt](docs/README.txt) and [docs/INSTRUCTIONS.txt](docs/INSTRUCTIONS.txt) for full instructions and troubleshooting tips.
+See [docs/README.txt](docs/README.txt)
+and [docs/INSTRUCTIONS.txt](docs/INSTRUCTIONS.txt) for full instructions and troubleshooting tips.
 
 ## Log messages
 


### PR DESCRIPTION
## Summary
- clarify setup and backup bullet points
- split docs reference into two lines

## Testing
- `powershell` command fails: command not found

------
https://chatgpt.com/codex/tasks/task_e_684b07d6c8b08332864bf27c95cd1014