### PR TITLE
Add git.exe fallback documentation and script update

### DIFF
--- a/docs/INSTRUCTIONS.txt
+++ b/docs/INSTRUCTIONS.txt
@@ -92,7 +92,8 @@ but keeps existing credentials and paths. All saved values appear as defaults ex
 Updating
 --------
 Run **update.ps1** at any time to pull the latest toolkit files from the repository.
-Git for Windows must be installed and in your PATH so this script can run.
+The script looks for `git` in your PATH and uses it when found.
+If Git for Windows is not installed, it falls back to `git.exe` bundled in this folder.
 
 Troubleshooting
 ---------------

--- a/docs/README.txt
+++ b/docs/README.txt
@@ -15,7 +15,7 @@ Main points
 * Runs on a schedule you choose (daily, every N hours, or weekly)
 * Shows live progress in the console and in backup.log
 * Optional Brevo e-mail when a run finishes, summarizing remote info, files transferred and data volume
-* `update.ps1` pulls new versions of these scripts via git (requires Git for Windows in PATH)
+* `update.ps1` pulls new versions of these scripts via git. If Git for Windows is not installed, it uses `git.exe` in this folder
 * Uses `--stats-log-level NOTICE` so totals appear in the log and e-mail
 * Setup lets you set timeouts and retry counts to avoid stalled transfers
 
@@ -40,7 +40,8 @@ Requirements
 * Your SFTP host, port, username, password
 * Disk space for the mirror plus snapshots
 * (Optional) Brevo v3 API key and a verified sender address
-* Git for Windows installed and in your PATH for update.ps1
+* (Optional) Git for Windows in your PATH for update.ps1
+  (script falls back to `git.exe` in this folder)
 
 Quick start
 -----------

--- a/update.ps1
+++ b/update.ps1
@@ -2,13 +2,22 @@
 
 $KitDir = $PSScriptRoot
 
-if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
-    Write-Error "git executable not found. Install Git for Windows and ensure 'git' is in your PATH."
-    exit 1
+$gitCmd = Get-Command git -ErrorAction SilentlyContinue
+if (-not $gitCmd) {
+    $LocalGit = Join-Path $KitDir 'git.exe'
+    if (Test-Path $LocalGit) {
+        Write-Warning "Using bundled git.exe because Git for Windows is not installed."
+        $gitCmd = $LocalGit
+    } else {
+        Write-Error "git executable not found. Install Git for Windows or keep git.exe in this folder."
+        exit 1
+    }
+} else {
+    $gitCmd = $gitCmd.Source
 }
 
 Write-Host "`nPulling updates from repository..."
-& git -C $KitDir pull
+& $gitCmd -C $KitDir pull
 if ($LASTEXITCODE -eq 0) {
     Write-Host 'Repository updated.'
 } else {


### PR DESCRIPTION
## Summary
- use bundled `git.exe` in `update.ps1` if no system Git is found
- mention the fallback in docs

## Testing
- `pwsh` was not available so `setup.ps1` and `backup.ps1` could not be tested

------
https://chatgpt.com/codex/tasks/task_e_684b07d7e53083328c9de7b1e165e8da