### PR TITLE
Improve git detection in update script

### DIFF
--- a/docs/INSTRUCTIONS.txt
+++ b/docs/INSTRUCTIONS.txt
@@ -92,7 +92,7 @@ but keeps existing credentials and paths. All saved values appear as defaults ex
 Updating
 --------
 Run **update.ps1** at any time to pull the latest toolkit files from the repository.
-Git for Windows must be installed and in your PATH so this script can run.
+It uses Git in PATH or `git.exe` in the toolkit folder.
 
 Troubleshooting
 ---------------

--- a/docs/README.txt
+++ b/docs/README.txt
@@ -15,7 +15,7 @@ Main points
 * Runs on a schedule you choose (daily, every N hours, or weekly)
 * Shows live progress in the console and in backup.log
 * Optional Brevo e-mail when a run finishes, summarizing remote info, files transferred and data volume
-* `update.ps1` pulls new versions of these scripts via git (requires Git for Windows in PATH)
+* `update.ps1` pulls new versions using Git in PATH or `git.exe` in this folder
 * Uses `--stats-log-level NOTICE` so totals appear in the log and e-mail
 * Setup lets you set timeouts and retry counts to avoid stalled transfers
 
@@ -40,7 +40,7 @@ Requirements
 * Your SFTP host, port, username, password
 * Disk space for the mirror plus snapshots
 * (Optional) Brevo v3 API key and a verified sender address
-* Git for Windows installed and in your PATH for update.ps1
+* Git for Windows in PATH or `git.exe` next to the scripts for update.ps1
 
 Quick start
 -----------

--- a/update.ps1
+++ b/update.ps1
@@ -2,13 +2,17 @@
 
 $KitDir = $PSScriptRoot
 
-if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
-    Write-Error "git executable not found. Install Git for Windows and ensure 'git' is in your PATH."
+$gitPath = (Get-Command git -ErrorAction SilentlyContinue).Path
+if (-not $gitPath) {
+    $gitPath = Join-Path $KitDir 'git.exe'
+}
+if (-not (Test-Path $gitPath)) {
+    Write-Error "git executable not found. Install Git for Windows or place git.exe in the toolkit folder."
     exit 1
 }
 
 Write-Host "`nPulling updates from repository..."
-& git -C $KitDir pull
+& $gitPath -C $KitDir pull
 if ($LASTEXITCODE -eq 0) {
     Write-Host 'Repository updated.'
 } else {


### PR DESCRIPTION
## Summary
- allow `update.ps1` to fall back to `git.exe` in the kit folder
- document new behaviour in `docs/README.txt` and `docs/INSTRUCTIONS.txt`

## Testing
- `pwsh --version` *(fails: command not found)*
- `powershell -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b07d9b39c83329a70293265b21332